### PR TITLE
Changed indentations to satisfy stricter rules imposed by Stanza 0.13.20

### DIFF
--- a/dependencies.stanza
+++ b/dependencies.stanza
@@ -79,9 +79,9 @@ defn obj-filename (filename:String) :
 ;; TODO: CURRENTLY DOESN'T HELP BECAUSE AREN'T PART OF MODELED DEPENDENCIES
 defn update-cpp-link (link:Link) :
   switch(os(link)) :
-  `Darwin :    [Link(os(link), to-tuple $ cat(value(link), ["-lc++"]))]
-  `GNU/Linux : [Link(os(link), to-tuple $ cat(value(link), ["-lstdc++"]))]
-  `* :         cat(update-cpp-link(Link(`Darwin, value(link))), update-cpp-link(Link(`GNU/Linux, value(link))))
+    `Darwin :    [Link(os(link), to-tuple $ cat(value(link), ["-lc++"]))]
+    `GNU/Linux : [Link(os(link), to-tuple $ cat(value(link), ["-lstdc++"]))]
+    `* :         cat(update-cpp-link(Link(`Darwin, value(link))), update-cpp-link(Link(`GNU/Linux, value(link))))
 
 defn update-cpp-package (pkg:Package) :
   Package(name(pkg), dependencies(pkg), to-list $ cat-all(seq(update-cpp-link, links(pkg))))

--- a/eval.stanza
+++ b/eval.stanza
@@ -253,10 +253,10 @@ public defn eval (env:List<Frame>, type?:True|False, sexpr) -> ? :
           `$def :
             val inits = eval(env, l[3])
             match(l[1]):
-            (name:Symbol) : add-binding(env, name, inits)
-            (names:List) :
-              for (name in tail(names), init in inits) do:
-                add-binding(env, name, init)
+              (name:Symbol) : add-binding(env, name, inits)
+              (names:List) :
+                for (name in tail(names), init in inits) do:
+                  add-binding(env, name, init)
           `$or :
             val t1 = eval(env, true, l[1])
             val t2 = eval(env, true, l[2])

--- a/gen-makefile.stanza
+++ b/gen-makefile.stanza
@@ -23,9 +23,9 @@ defn obj-filename (filename:String) :
 ;; TODO: CURRENTLY DOESN'T HELP BECAUSE AREN'T PART OF MODELED DEPENDENCIES
 defn update-cpp-link (link:Link) :
   switch(os(link)) :
-  `Darwin :    [Link(os(link), to-tuple $ cat(value(link), ["-lc++"]))]
-  `GNU/Linux : [Link(os(link), to-tuple $ cat(value(link), ["-lstdc++"]))]
-  `* :         cat(update-cpp-link(Link(`Darwin, value(link))), update-cpp-link(Link(`GNU/Linux, value(link))))
+    `Darwin :    [Link(os(link), to-tuple $ cat(value(link), ["-lc++"]))]
+    `GNU/Linux : [Link(os(link), to-tuple $ cat(value(link), ["-lstdc++"]))]
+    `* :         cat(update-cpp-link(Link(`Darwin, value(link))), update-cpp-link(Link(`GNU/Linux, value(link))))
 
 defn update-cpp-package (pkg:Package) :
   Package(name(pkg), dependencies(pkg), to-list $ cat-all(seq(update-cpp-link, links(pkg))))

--- a/gen-repl.stanza
+++ b/gen-repl.stanza
@@ -93,9 +93,9 @@ defn visit (s:OutputStream, build-name:String, pkg-name:Symbol, directs:HashSet<
       (t) : true
   defn include-function? (fid:LSFnId|FnId|MultiId) :
     match(fid) :
-    (lfid:LSFnId) :
-       not contains?([`next-int], name(fid)) and
-         length(targs(fid)) == 0 and all?(ref?, a1(fid)) and ref?(a2(fid)) and all?(public-type?, a1(fid)) and public-type?(a2(fid))
+      (lfid:LSFnId) :
+         not contains?([`next-int], name(fid)) and
+           length(targs(fid)) == 0 and all?(ref?, a1(fid)) and ref?(a2(fid)) and all?(public-type?, a1(fid)) and public-type?(a2(fid))
     (rfid:FnId|MultiId) :
       val res = true and ;; all?(public-type?, a1(fid)) and public-type?(a2(fid)) and
         not contains?([`min `max], name(fid)) and


### PR DESCRIPTION
Stanza 0.13.20 adds a stricter lexing rule to prevent accidental indented blocks.

The following is no longer allowed:

```
for i in 0 to 10 do:
println(i)
```

Where the body is at the same indentation level as the previous block.